### PR TITLE
Add redundant brace rule in scalafmt

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -6,3 +6,7 @@ align.openParenCallSite = false
 align.openParenDefnSite = false
 binPack.literalArgumentLists = true
 version = "2.7.3"
+
+rewrite.rules = [RedundantBraces]
+rewrite.redundantBraces.methodBodies = true
+rewrite.redundantBraces.maxLines = 1

--- a/grpc-runtime/src/main/scala/monix/grpc/runtime/client/ClientCall.scala
+++ b/grpc-runtime/src/main/scala/monix/grpc/runtime/client/ClientCall.scala
@@ -135,7 +135,6 @@ object ClientCall {
       channel: grpc.Channel,
       methodDescriptor: grpc.MethodDescriptor[Request, Response],
       callOptions: grpc.CallOptions
-  ): ClientCall[Request, Response] = {
+  ): ClientCall[Request, Response] =
     new ClientCall(channel.newCall[Request, Response](methodDescriptor, callOptions))
-  }
 }

--- a/grpc-runtime/src/main/scala/monix/grpc/runtime/utils/ObservableOps.scala
+++ b/grpc-runtime/src/main/scala/monix/grpc/runtime/utils/ObservableOps.scala
@@ -7,7 +7,7 @@ import monix.execution.Scheduler
 object ObservableOps {
   def deferAction[T](action: Scheduler => Observable[T]): Observable[T] = {
     Observable.fromTask {
-      Task.deferAction { scheduler => Task(action(scheduler)) }
+      Task.deferAction(scheduler => Task(action(scheduler)))
     }.flatten
   }
 }


### PR DESCRIPTION
This is to give you an idea what the impact of this scalafmt feature would be.
I rather have it autoformatted then having to manually suspect if this needs or doesn't need braces.
i.e. this is a clear definition of 'rules'.

BTW looking at the diffs it seems to do the rules you want :+1: 