### PR TITLE
Don't use atomics in client and server listeners

### DIFF
--- a/grpc-runtime/src/main/scala/monix/grpc/runtime/client/ClientCallListeners.scala
+++ b/grpc-runtime/src/main/scala/monix/grpc/runtime/client/ClientCallListeners.scala
@@ -42,8 +42,8 @@ object ClientCallListeners {
         if (!callStatus.isOk) Task.raiseError(callStatus.toException)
         else {
           response0 match {
-            case Some(response) if response != null => Task.now(response)
-            case (None | Some(null)) =>
+            case Some(response) => Task.now(response)
+            case None =>
               val errMsg = "No value received for unary client call!"
               val errStatus = grpc.Status.INTERNAL.withDescription(errMsg)
               Task.raiseError(errStatus.asRuntimeException(callStatus.trailers))
@@ -55,7 +55,7 @@ object ClientCallListeners {
     override def onHeaders(headers: grpc.Metadata): Unit =
       headers0 = Some(headers)
     override def onMessage(message: Response): Unit = response0 match {
-      case None => response0 = Some(message)
+      case None => response0 = Option(message)
       case Some(_) =>
         val errMsg = "Too many response messages, expected only one!"
         val errStatus = grpc.Status.INTERNAL.withDescription(errMsg)

--- a/grpc-runtime/src/main/scala/monix/grpc/runtime/server/ServerCallHandlers.scala
+++ b/grpc-runtime/src/main/scala/monix/grpc/runtime/server/ServerCallHandlers.scala
@@ -94,8 +94,8 @@ object ServerCallHandlers {
         _ <- Task.fromCancelablePromise(completed)
         _ <- call.sendHeaders(metadata)
         _ <- requestMsg match {
-          case Some(msg) if msg != null => sendResponse(msg)
-          case (None | Some(null)) =>
+          case Some(msg) => sendResponse(msg)
+          case None =>
             val errMsg = "Missing request message for unary call!"
             val errStatus = grpc.Status.INTERNAL.withDescription(errMsg)
             Task.raiseError(errStatus.asRuntimeException(metadata))
@@ -116,7 +116,7 @@ object ServerCallHandlers {
 
     override def onMessage(msg: T): Unit = requestMsg match {
       case None =>
-        requestMsg = Some(msg)
+        requestMsg = Option(msg)
       case Some(msg) =>
         val errMsg = "Too many requests received for unary request"
         val errStatus = grpc.Status.INTERNAL.withDescription(errMsg)


### PR DESCRIPTION
The underlying grpc engine serializes all calls so that one doesn't to
synchronize any kind of state in the listeners. Thus, we can get rid of
any synchronization.