### PR TITLE
Add the imports of the scalapb options to the generated Api code

### DIFF
--- a/grpc-codegen/src/main/scala/monix/grpc/codegen/GrpcCodeGenerator.scala
+++ b/grpc-codegen/src/main/scala/monix/grpc/codegen/GrpcCodeGenerator.scala
@@ -43,7 +43,7 @@ object GrpcCodeGenerator extends CodeGenApp {
     file.getServices.asScala.map { service =>
       import implicits.{FileDescriptorPimp, ServiceDescriptorPimp}
 
-      val p = new GrpcServicePrinter(service, params.serviceSuffix, implicits)
+      val p = new GrpcServicePrinter(file, service, params.serviceSuffix, implicits)
       val code = p.printService(FunctionalPrinter()).result()
       val fileName = s"${file.scalaDirectory}/${service.name}${params.serviceSuffix}.scala"
 

--- a/grpc-codegen/src/main/scala/monix/grpc/codegen/GrpcServicePrinter.scala
+++ b/grpc-codegen/src/main/scala/monix/grpc/codegen/GrpcServicePrinter.scala
@@ -1,10 +1,13 @@
 package monix.grpc.codegen
 
 import scalapb.compiler.FunctionalPrinter.PrinterEndo
-import com.google.protobuf.Descriptors.{MethodDescriptor, ServiceDescriptor}
+import com.google.protobuf.Descriptors.{FileDescriptor, MethodDescriptor, ServiceDescriptor}
 import scalapb.compiler.{DescriptorImplicits, FunctionalPrinter, NameUtils, PrinterEndo, StreamType}
 
+import scala.jdk.CollectionConverters._
+
 class GrpcServicePrinter(
+    file: FileDescriptor,
     service: ServiceDescriptor,
     serviceSuffix: String,
     implicits: DescriptorImplicits
@@ -97,6 +100,9 @@ class GrpcServicePrinter(
   def printService(printer: FunctionalPrinter): FunctionalPrinter = {
     printer
       .add(s"package $servicePkgName", "")
+      .print(file.scalaOptions.getImportList.asScala) { case (printer, i) =>
+        printer.add(s"import $i")
+      }
       .add(s"trait $serviceNameMonix {")
       .indent
       .seq(service.methods.map(serviceMethodSignature))


### PR DESCRIPTION
This is needed for the method descriptions to work when using type modifiers and probably some other feature of scalapb.
```proto
option (scalapb.options) = {
    scope: PACKAGE
//this was not picked by the generator, thus any RPC returning `ours.common.Energy` resulted in an error.
    import: "ours.protobuf.Conversions._"
    aux_message_options: [
        {
            target: "ours.protobuf.Energy"
            options: {
                type: "ours.common.Energy"
            }
        }
};
```