### PR TITLE
Add support for scala 3 to the project

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,9 @@
 val Scala213 = "2.13.4"
 val Scala212 = "2.12.12"
-
+val Scala3 = "3.0.0"
+import scalapb.compiler.Version.grpcJavaVersion
+import scalapb.compiler.Version.scalapbVersion
+val scalaVersions = Seq(Scala212, Scala213, Scala3)
 ThisBuild / scalaVersion := Scala212
 
 inThisBuild(
@@ -36,15 +39,15 @@ lazy val grpcRuntime = project
   .settings(releaseSettings)
   .settings(
     name := "monix-grpc-runtime",
-    crossScalaVersions := List("2.12.12", "2.13.3"),
+    crossScalaVersions := scalaVersions,
     testFrameworks += new TestFramework("munit.Framework"),
     libraryDependencies ++= List(
-      "io.grpc" % "grpc-api" % "1.36.0",
-      "io.monix" %% "monix" % "3.2.2",
-      "com.thesamet.scalapb" %% "scalapb-runtime" % "0.10.9",
-      "io.grpc" % "grpc-stub" % "1.36.0" % Test,
-      "io.grpc" % "grpc-protobuf" % "1.36.0" % Test,
-      "org.scalameta" %% "munit" % "0.7.22" % Test
+      "io.grpc" % "grpc-api" % grpcJavaVersion,
+      "io.monix" %% "monix" % "3.4.0",
+      "com.thesamet.scalapb" %% "scalapb-runtime" % scalapbVersion,
+      "io.grpc" % "grpc-stub" % grpcJavaVersion % Test,
+      "io.grpc" % "grpc-protobuf" % grpcJavaVersion % Test,
+      "org.scalameta" %% "munit" % "0.7.26" % Test
     )
   )
 
@@ -59,10 +62,10 @@ lazy val grpcCodeGen = projectMatrix
     buildInfoPackage := "monix.grpc.codegen.build",
     name := "monix-grpc-codegen",
     libraryDependencies ++= Seq(
-      "com.thesamet.scalapb" %% "compilerplugin" % scalapb.compiler.Version.scalapbVersion
+      "com.thesamet.scalapb" %% "compilerplugin" % scalapbVersion
     )
   )
-  .jvmPlatform(scalaVersions = Seq(Scala212, Scala213))
+  .jvmPlatform(scalaVersions = scalaVersions)
 
 lazy val codeGenJVM212 = grpcCodeGen.jvm(Scala212)
 
@@ -78,22 +81,21 @@ lazy val e2e = project
   .dependsOn(grpcRuntime)
   .enablePlugins(LocalCodeGenPlugin)
   .settings(
-    crossScalaVersions := Seq("2.12.12", "2.13.3"),
-    skip in publish := true,
+    crossScalaVersions := scalaVersions,
+    publish / skip := true,
     libraryDependencies ++= Seq(
-      "com.thesamet.scalapb" %% "scalapb-runtime-grpc" % scalapb.compiler.Version.scalapbVersion,
-      "io.grpc" % "grpc-netty" % "1.36.0",
-      "org.scalameta" %% "munit" % "0.7.22",
-      "com.typesafe.scala-logging" %% "scala-logging" % "3.9.2",
+      "com.thesamet.scalapb" %% "scalapb-runtime-grpc" % scalapbVersion,
+      "io.grpc" % "grpc-netty" % grpcJavaVersion,
+      "org.scalameta" %% "munit" % "0.7.26",
       "org.slf4j" % "slf4j-api" % "1.7.30",
       "org.apache.logging.log4j" % "log4j-slf4j-impl" % "2.13.3"
     ),
     testFrameworks += new TestFramework("munit.Framework"),
-    PB.targets in Compile := Seq(
-      scalapb.gen(grpc = false) -> (sourceManaged in Compile).value,
+    Compile / PB.targets := Seq(
+      scalapb.gen(grpc = false) -> (Compile / sourceManaged).value,
       genModule(
         "monix.grpc.codegen.GrpcCodeGenerator$"
-      ) -> (sourceManaged in Compile).value
+      ) -> (Compile / sourceManaged).value
     ),
     PB.protocVersion := "3.13.0",
     codeGenClasspath := (codeGenJVM212 / Compile / fullClasspath).value

--- a/e2e/src/test/scala/scalapb/monix/grpc/testservice/BackpressureSpec.scala
+++ b/e2e/src/test/scala/scalapb/monix/grpc/testservice/BackpressureSpec.scala
@@ -1,6 +1,5 @@
 package scalapb.monix.grpc.testservice
 
-import com.typesafe.scalalogging.LazyLogging
 import io.grpc.Metadata
 import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
@@ -22,7 +21,7 @@ class BackpressureSpec extends GrpcBaseSpec {
     state.withClientStream(sendRequests(100, Scenario.SLOW, _)) { clientRequests0 =>
       val events = new mutable.ListBuffer[Long]()
       val clientRequests = clientRequests0
-        .doOnNext(_ => Task(events.+=(Instant.now().toEpochMilli())))
+        .doOnNext(_ => Task(events.+=(Instant.now().toEpochMilli())).void)
 
       state.stub.bidiStreaming(clientRequests).completedL.map { _ =>
         assertBackpressureFromTimestamps(100, events.toList)
@@ -44,7 +43,7 @@ class BackpressureSpec extends GrpcBaseSpec {
     state.withClientStream(sendRequests(100, Scenario.SLOW, _)) { clientRequests0 =>
       val events = new mutable.ListBuffer[Long]()
       val clientRequests = clientRequests0
-        .doOnNext(_ => Task(events.+=(Instant.now().toEpochMilli())))
+        .doOnNext(_ => Task(events.+=(Instant.now().toEpochMilli())).void)
 
       state.stub.clientStreaming(clientRequests).map { _ =>
         assertBackpressureFromTimestamps(100, events.toList)
@@ -61,7 +60,7 @@ class BackpressureSpec extends GrpcBaseSpec {
   }
 
   private def generateRequest(idx: Int, scenario: Scenario): Request =
-    Request(scenario, idx, Array.fill(10)(Random.nextDouble()))
+    Request(scenario, idx, IndexedSeq.fill(10)(Random.nextDouble()))
   private def sendRequests(
       count: Int,
       scenario: Scenario,

--- a/e2e/src/test/scala/scalapb/monix/grpc/testservice/TestService.scala
+++ b/e2e/src/test/scala/scalapb/monix/grpc/testservice/TestService.scala
@@ -1,9 +1,9 @@
 package scalapb.monix.grpc.testservice
 
-import com.typesafe.scalalogging.{LazyLogging, Logger}
 import io.grpc._
 import monix.eval.Task
 import monix.reactive.Observable
+import org.slf4j.Logger
 import scalapb.monix.grpc.testservice.Request.Scenario
 
 import java.time.Instant
@@ -83,7 +83,7 @@ class TestService(logger: Logger) extends TestServiceApi {
   }
 
   private def generateLargeResponse(id: Int): Response =
-    Response(id, Instant.now().toEpochMilli, Array.fill(10)(Random.nextDouble()))
+    Response(id, Instant.now().toEpochMilli, IndexedSeq.fill(10)(Random.nextDouble()))
   private def generateNextResponseFrom(response: Response): Response =
     response.copy(out = response.out + 1, timestamp = Instant.now.toEpochMilli())
 }

--- a/e2e/src/test/scala/scalapb/monix/grpc/testservice/TestServiceSpec.scala
+++ b/e2e/src/test/scala/scalapb/monix/grpc/testservice/TestServiceSpec.scala
@@ -1,7 +1,6 @@
 package scalapb.monix.grpc.testservice
 
 import munit.Location
-import com.typesafe.scalalogging.LazyLogging
 import io.grpc.{Metadata, Server, StatusRuntimeException}
 import monix.eval.Task
 import monix.reactive.subjects.{PublishSubject, ReplaySubject, Subject}

--- a/grpc-codegen/src/main/scala/monix/grpc/codegen/GrpcCodeGenerator.scala
+++ b/grpc-codegen/src/main/scala/monix/grpc/codegen/GrpcCodeGenerator.scala
@@ -41,7 +41,7 @@ object GrpcCodeGenerator extends CodeGenApp {
   ): Seq[CodeGeneratorResponse.File] = {
     import scala.jdk.CollectionConverters._
     file.getServices.asScala.map { service =>
-      import implicits.{FileDescriptorPimp, ServiceDescriptorPimp}
+      import implicits._
 
       val p = new GrpcServicePrinter(service, params.serviceSuffix, implicits)
       val code = p.printService(FunctionalPrinter()).result()

--- a/grpc-codegen/src/main/scala/monix/grpc/codegen/GrpcServicePrinter.scala
+++ b/grpc-codegen/src/main/scala/monix/grpc/codegen/GrpcServicePrinter.scala
@@ -41,7 +41,7 @@ class GrpcServicePrinter(
   private[this] val serverCalls = "_root_.io.grpc.stub.ServerCalls"
 
   private[this] def methodDescriptor(method: MethodDescriptor) = PrinterEndo { p =>
-    def marshaller(t: MethodDescriptorPimp#MethodTypeWrapper) =
+    def marshaller(t: ExtendedMethodDescriptor#MethodTypeWrapper) =
       if (t.customScalaType.isDefined)
         s"_root_.scalapb.grpc.Marshaller.forTypeMappedType[${t.baseScalaType}, ${t.scalaType}]"
       else
@@ -56,25 +56,29 @@ class GrpcServicePrinter(
 
     val grpcMethodDescriptor = "_root_.io.grpc.MethodDescriptor"
 
-    p.add(
-      s"""${method.deprecatedAnnotation}val ${method.grpcDescriptor.nameSymbol}: $grpcMethodDescriptor[${method.inputType.scalaType}, ${method.outputType.scalaType}] =
-         |  $grpcMethodDescriptor.newBuilder()
-         |    .setType($grpcMethodDescriptor.MethodType.$methodType)
-         |    .setFullMethodName($grpcMethodDescriptor.generateFullMethodName("${service.getFullName}", "${method.getName}"))
-         |    .setSampledToLocalTracing(true)
-         |    .setRequestMarshaller(${marshaller(method.inputType)})
-         |    .setResponseMarshaller(${marshaller(method.outputType)})
-         |    .setSchemaDescriptor(_root_.scalapb.grpc.ConcreteProtoMethodDescriptorSupplier.fromMethodDescriptor(${method.javaDescriptorSource}))
-         |    .build()
-         |""".stripMargin
-    )
+    p.indent
+      .add(
+        s"""${method.deprecatedAnnotation}val ${method.grpcDescriptor.nameSymbol}: $grpcMethodDescriptor[${method.inputType.scalaType}, ${method.outputType.scalaType}] =
+           |  $grpcMethodDescriptor.newBuilder()
+           |    .setType($grpcMethodDescriptor.MethodType.$methodType)
+           |    .setFullMethodName($grpcMethodDescriptor.generateFullMethodName("${service.getFullName}", "${method.getName}"))
+           |    .setSampledToLocalTracing(true)
+           |    .setRequestMarshaller(${marshaller(method.inputType)})
+           |    .setResponseMarshaller(${marshaller(method.outputType)})
+           |    .setSchemaDescriptor(_root_.scalapb.grpc.ConcreteProtoMethodDescriptorSupplier.fromMethodDescriptor(${method.javaDescriptorSource}))
+           |    .build()
+           |""".stripMargin
+      )
+      .outdent
   }
 
   private[this] def serviceDescriptor(service: ServiceDescriptor) = {
     val grpcServiceDescriptor = "_root_.io.grpc.ServiceDescriptor"
 
     PrinterEndo(
-      _.add(s"val ${service.grpcDescriptor.nameSymbol}: $grpcServiceDescriptor =").indent
+      _.indent
+        .add(s"val ${service.grpcDescriptor.nameSymbol}: $grpcServiceDescriptor =")
+        .indent
         .add(s"""$grpcServiceDescriptor.newBuilder("${service.getFullName}")""")
         .indent
         .add(
@@ -84,6 +88,7 @@ class GrpcServicePrinter(
           p.add(s".addMethod(${method.grpcDescriptor.nameSymbol})")
         }
         .add(".build()")
+        .outdent
         .outdent
         .outdent
         .newline

--- a/grpc-runtime/src/test/scala/monix/grpc/runtime/server/ServerCallTest.scala
+++ b/grpc-runtime/src/test/scala/monix/grpc/runtime/server/ServerCallTest.scala
@@ -30,7 +30,7 @@ class ServerCallTest extends FunSuite {
   }
 
   test("requests new elements as they are being processed") {
-    val mock = ServerCallMock[Int, Int]
+    val mock = ServerCallMock[Int, Int]()
     val testSubscriber = TestSubscriber[Int](false)
     val listener =
       new StreamingCallListener[Int, Int](
@@ -71,7 +71,7 @@ class ServerCallTest extends FunSuite {
   }
 
   test("onReadyEffect is triggered onReady") {
-    val mock = ServerCallMock[Int, Int]
+    val mock = ServerCallMock[Int, Int]()
     val listener =
       new StreamingCallListener[Int, Int](
         ServerCall(mock, ServerCallOptions.default),
@@ -85,7 +85,7 @@ class ServerCallTest extends FunSuite {
   }
 
   test("rpc call is cancelled successfully") {
-    val mock = ServerCallMock[Int, Int]
+    val mock = ServerCallMock[Int, Int]()
     val listener =
       new StreamingCallListener[Int, Int](
         ServerCall(mock, ServerCallOptions.default),

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.6
+sbt.version=1.5.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,9 +2,9 @@ resolvers += Resolver.sonatypeRepo("staging")
 resolvers += Resolver.sonatypeRepo("snapshots")
 resolvers += Resolver.bintrayIvyRepo("sbt", "sbt-plugin-releases")
 
-addSbtPlugin("com.thesamet" % "sbt-protoc" % "1.0.1")
+addSbtPlugin("com.thesamet" % "sbt-protoc" % "1.0.4")
 addSbtPlugin("com.thesamet" % "sbt-protoc-gen-project" % "0.1.6")
-libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.10.11"
+libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.11.3"
 
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.10.0")
@@ -12,4 +12,4 @@ addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.10.0")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.8.1")
 addSbtPlugin("ch.epfl.scala" % "sbt-release-early" % "2.1.1+10-c6ef3f60")
-addSbtPlugin("com.eed3si9n" % "sbt-projectmatrix" % "0.7.0")
+addSbtPlugin("com.eed3si9n" % "sbt-projectmatrix" % "0.8.0")


### PR DESCRIPTION
Add scala 3 support, update dependencies and sbt plugins.
Update tests to avoid deprecation warnings.
Update the generator to have the right indentations to avoid scala 3 warnings.
Use slf4j logging because scala-logging macros don't work.